### PR TITLE
switch to python3 only syntax

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
-#coding:utf8
-from __future__ import print_function, division, unicode_literals
-import io
+#!/usr/bin/env python3
+
 import json
 import models
 import utils
@@ -87,15 +85,15 @@ def train():
     logging.info('Loading vocab,train and val dataset.Wait a second,please')
     
     embed = torch.Tensor(np.load(args.embedding)['embedding'])
-    with io.open(args.word2id, encoding='utf-8') as f:
+    with open(args.word2id) as f:
         word2id = json.load(f)
     vocab = utils.Vocab(embed, word2id)
 
-    with io.open(args.train_dir, encoding='utf-8') as f:
+    with open(args.train_dir) as f:
         examples = [json.loads(line) for line in f]
     train_dataset = utils.Dataset(examples)
 
-    with io.open(args.val_dir, encoding='utf-8') as f:
+    with open(args.val_dir) as f:
         examples = [json.loads(line) for line in f]
     val_dataset = utils.Dataset(examples)
 
@@ -154,11 +152,11 @@ def train():
 def test():
      
     embed = torch.Tensor(np.load(args.embedding)['embedding'])
-    with io.open(args.word2id, encoding='utf-8') as f:
+    with open(args.word2id) as f:
         word2id = json.load(f)
     vocab = utils.Vocab(embed, word2id)
 
-    with io.open(args.test_dir, encoding='utf-8') as f:
+    with open(args.test_dir) as f:
         examples = [json.loads(line) for line in f]
     test_dataset = utils.Dataset(examples)
 
@@ -202,10 +200,10 @@ def test():
             doc = batch['doc'][doc_id].split('\n')[:doc_len]
             hyp = [doc[index] for index in topk_indices]
             ref = summaries[doc_id]
-            with io.open(os.path.join(args.ref,str(file_id)+'.txt'), 'w', encoding='utf-8') as f:
-                f.write(unicode(ref))
-            with io.open(os.path.join(args.hyp,str(file_id)+'.txt'), 'w', encoding='utf-8') as f:
-                f.write(unicode('\n'.join(hyp)))
+            with open(os.path.join(args.ref,str(file_id)+'.txt'), 'w') as f:
+                f.write(ref)
+            with open(os.path.join(args.hyp,str(file_id)+'.txt'), 'w') as f:
+                f.write('\n'.join(hyp))
             start = stop
             file_id = file_id + 1
     print('Speed: %.2f docs / s' % (doc_num / time_cost))

--- a/models/BasicModule.py
+++ b/models/BasicModule.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#coding:utf8
 import torch
 from torch.autograd import Variable
 class BasicModule(torch.nn.Module):

--- a/models/CNN_RNN.py
+++ b/models/CNN_RNN.py
@@ -1,10 +1,9 @@
-#!/usr/bin/env python
-#coding:utf8
 from .BasicModule import BasicModule
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
+
 class CNN_RNN(BasicModule):
     def __init__(self, args, embed=None):
         super(CNN_RNN,self).__init__()

--- a/models/RNN.py
+++ b/models/RNN.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#coding:utf8
 from .BasicModule import BasicModule
 import torch
 import torch.nn as nn

--- a/outputs/eval.py
+++ b/outputs/eval.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env python3
+
 import os
 from pyrouge import Rouge155
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import json
 import numpy as np
@@ -93,7 +95,7 @@ def build_dataset(args):
     multi_res = [p.apply_async(worker,(fs,)) for fs in groups]
     res = [res.get() for res in multi_res]
     
-    with open(args.target_dir,'w',encoding='utf8') as f:
+    with open(args.target_dir, 'w') as f:
         for row in chain(*res):
             f.write(json.dumps(row, ensure_ascii=False) + "\n")
 


### PR DESCRIPTION
- removed the `__future__` imports
- removed the `#coding:utf8`
- changed shebang to `#!/usr/bin/env python3`
- switched `io.open` to just `open` and removed `encoding='utf-8'` argument
- no longer need to use `unicode` function to encode
- ensured no explicit use of str.encode/str.decode

*NOTE* I did not get a chance to thoroughly test this PR by building and running a model.